### PR TITLE
Also do element backgrounds

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -23,3 +23,6 @@ along with Moodle.  If not, see <https://www.gnu.org/licenses/>. */
 body.accessibility-imagevisibility-enabled img:not(.colourdialogue) {
     visibility: hidden !important;
 }
+body.accessibility-imagevisibility-enabled * {
+	background-image: unset !important;
+}

--- a/styles.css
+++ b/styles.css
@@ -24,5 +24,5 @@ body.accessibility-imagevisibility-enabled img:not(.colourdialogue) {
     visibility: hidden !important;
 }
 body.accessibility-imagevisibility-enabled * {
-	background-image: unset !important;
+    background-image: unset !important;
 }


### PR DESCRIPTION
In one Moodle, I noticed course images on the dashboard were still visible. Those cards use the background-image CSS rather than an img tag.